### PR TITLE
fix control numbers and raise relevant error

### DIFF
--- a/quconot/implementations/mct_barenco_74_dirty.py
+++ b/quconot/implementations/mct_barenco_74_dirty.py
@@ -16,10 +16,10 @@ from .mct_base import MCTBase
 
 class MCTBarenco74Dirty(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert controls_no >= 2
+        if controls_no < 5:
+            raise ValueError("Number of controls must be >= 5 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     def TofDecomp(self):
         qc = QuantumCircuit(3)

--- a/quconot/implementations/mct_barenco_75_dirty.py
+++ b/quconot/implementations/mct_barenco_75_dirty.py
@@ -15,10 +15,10 @@ from .mct_base import MCTBase
 
 class MCTBarenco75Dirty(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert controls_no >= 2
+        if controls_no < 2:
+            raise ValueError("Number of controls must be >= 2 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     def get_V(self, root: int):
         circ = QuantumCircuit(2, name=f"CX^1/{root}")

--- a/quconot/implementations/mct_base.py
+++ b/quconot/implementations/mct_base.py
@@ -5,10 +5,10 @@ from qiskit import QuantumCircuit
 
 class MCTBase:
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert controls_no >= 2
+        if controls_no < 2:
+            raise ValueError("Number of controls must be >= 2 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     @classmethod
     def verify_mct_cases(

--- a/quconot/implementations/mct_n_qubit_decomposition.py
+++ b/quconot/implementations/mct_n_qubit_decomposition.py
@@ -32,10 +32,10 @@ from .mct_base import MCTBase
 
 class MCTNQubitDecomposition(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert controls_no >= 2
+        if controls_no < 5:
+            raise ValueError("Number of controls must be >= 5 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     def RyDecomp(self):
         ry_circuit = QuantumCircuit(1)

--- a/quconot/implementations/mct_no_auxiliary.py
+++ b/quconot/implementations/mct_no_auxiliary.py
@@ -15,10 +15,10 @@ from .mct_base import MCTBase
 
 class MCTNoAuxiliary(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert controls_no >= 2
+        if controls_no < 2:
+            raise ValueError("Number of controls must be >= 2 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     @classmethod
     def verify_mct_cases(

--- a/quconot/implementations/mct_no_auxiliary_relative.py
+++ b/quconot/implementations/mct_no_auxiliary_relative.py
@@ -15,12 +15,10 @@ from .mct_base import MCTBase
 
 class MCTNoAuxiliaryRelative(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert (
-            controls_no >= 2 and controls_no <= 3
-        ), "At the moment we cannot handle controls bigger than 3."
+        if controls_no not in [2,3]:
+            raise ValueError("Number of controls must be 2 or 3 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     @classmethod
     def verify_mct_cases(

--- a/quconot/implementations/mct_no_auxiliary_relative.py
+++ b/quconot/implementations/mct_no_auxiliary_relative.py
@@ -15,7 +15,7 @@ from .mct_base import MCTBase
 
 class MCTNoAuxiliaryRelative(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        if controls_no not in [2,3]:
+        if controls_no not in [2, 3]:
             raise ValueError("Number of controls must be 2 or 3 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None

--- a/quconot/implementations/mct_parallel_decomposition.py
+++ b/quconot/implementations/mct_parallel_decomposition.py
@@ -14,10 +14,10 @@ from .mct_base import MCTBase
 
 class MCTParallelDecomposition(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert controls_no >= 2
+        if controls_no < 3:
+            raise ValueError("Number of controls must be >= 3 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     def get_toffoli(self, qc: QuantumCircuit, c1: List[list], c2: List[list], t: int):
         qc.toffoli(c1, c2, t)

--- a/quconot/implementations/mct_recursion.py
+++ b/quconot/implementations/mct_recursion.py
@@ -15,10 +15,10 @@ from .mct_base import MCTBase
 
 class MCTRecursion(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert controls_no >= 2
+        if controls_no < 2:
+            raise ValueError("Number of controls must be >= 2 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     @classmethod
     def verify_mct_cases(

--- a/quconot/implementations/mct_vchain.py
+++ b/quconot/implementations/mct_vchain.py
@@ -15,10 +15,10 @@ from .mct_base import MCTBase
 
 class MCTVChain(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert controls_no >= 2
+        if controls_no < 2:
+            raise ValueError("Number of controls must be >= 2 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     @classmethod
     def verify_mct_cases(

--- a/quconot/implementations/mct_vchain_dirty.py
+++ b/quconot/implementations/mct_vchain_dirty.py
@@ -15,10 +15,10 @@ from .mct_base import MCTBase
 
 class MCTVChainDirty(MCTBase):
     def __init__(self, controls_no: int, **kwargs) -> None:
-        assert controls_no >= 2
+        if controls_no < 2:
+            raise ValueError("Number of controls must be >= 2 for this implementation")
         self._n = controls_no
         self._circuit: QuantumCircuit = None
-        pass
 
     @classmethod
     def verify_mct_cases(

--- a/test/implementations/test_mct_barenco_74_dirty.py
+++ b/test/implementations/test_mct_barenco_74_dirty.py
@@ -58,10 +58,10 @@ class TestMCTBarenco74Dirty:
         return self._auxiliary_dict[controls_no]
 
     def test_init(self):
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(
+            ValueError, match="Number of controls must be >= 5 for this implementation"
+        ):
             MCTBarenco74Dirty(2)
-
-        assert e_info.value.args[0] == "Number of controls must be >= 5 for this implementation"
 
         assert MCTBarenco74Dirty(5)
 

--- a/test/implementations/test_mct_barenco_74_dirty.py
+++ b/test/implementations/test_mct_barenco_74_dirty.py
@@ -63,7 +63,10 @@ class TestMCTBarenco74Dirty:
         ):
             MCTBarenco74Dirty(2)
 
-        assert MCTBarenco74Dirty(5)
+        try:
+            MCTBarenco74Dirty(5)
+        except Exception:
+            assert False, "object MCTBarenco74Dirty(5) was not created, but it should be"
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_barenco_74_dirty.py
+++ b/test/implementations/test_mct_barenco_74_dirty.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import numpy as np
+import pytest
 from functions_testing import (
     verify_circuit_clean_auxiliary,
     verify_circuit_clean_relative_auxiliary,
@@ -55,6 +56,14 @@ class TestMCTBarenco74Dirty:
         self._auxiliary_dict[controls_no] = mct.num_auxiliary_qubits()
 
         return self._auxiliary_dict[controls_no]
+
+    def test_init(self):
+        with pytest.raises(Exception) as e_info:
+            MCTBarenco74Dirty(2)
+
+        assert e_info.value.args[0] == "Number of controls must be >= 5 for this implementation"
+
+        assert MCTBarenco74Dirty(5)
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_barenco_75_dirty.py
+++ b/test/implementations/test_mct_barenco_75_dirty.py
@@ -41,7 +41,10 @@ class TestMCTBarenco75Dirty:
         ):
             MCTBarenco75Dirty(1)
 
-        assert MCTBarenco75Dirty(2)
+        try:
+            MCTBarenco75Dirty(2)
+        except Exception:
+            assert False, "object MCTBarenco75Dirty(2) was not created, but it should be"
 
     def test_circuit_no_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_barenco_75_dirty.py
+++ b/test/implementations/test_mct_barenco_75_dirty.py
@@ -35,10 +35,11 @@ class TestMCTBarenco75Dirty:
             return self._matrix_dict[controls_no]
 
     def test_init(self):
-        with pytest.raises(Exception) as e_info:
-            MCTBarenco75Dirty(1)
 
-        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
+        with pytest.raises(
+            ValueError, match="Number of controls must be >= 2 for this implementation"
+        ):
+            MCTBarenco75Dirty(1)
 
         assert MCTBarenco75Dirty(2)
 

--- a/test/implementations/test_mct_barenco_75_dirty.py
+++ b/test/implementations/test_mct_barenco_75_dirty.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import numpy as np
+import pytest
 from functions_testing import verify_circuit_no_auxiliary, verify_circuit_no_auxiliary_relative
 from qiskit.quantum_info.operators import Operator
 
@@ -32,6 +33,14 @@ class TestMCTBarenco75Dirty:
             return self._reverse_matrix_dict[controls_no]
         else:
             return self._matrix_dict[controls_no]
+
+    def test_init(self):
+        with pytest.raises(Exception) as e_info:
+            MCTBarenco75Dirty(1)
+
+        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
+
+        assert MCTBarenco75Dirty(2)
 
     def test_circuit_no_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_n_qubit_decomposition.py
+++ b/test/implementations/test_mct_n_qubit_decomposition.py
@@ -63,7 +63,10 @@ class TestMCTNQubitDecomposition:
         ):
             MCTNQubitDecomposition(2)
 
-        assert MCTNQubitDecomposition(5)
+        try:
+            MCTNQubitDecomposition(5)
+        except Exception:
+            assert False, "object MCTNQubitDecomposition(5) was not created, but it should be"
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_n_qubit_decomposition.py
+++ b/test/implementations/test_mct_n_qubit_decomposition.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import numpy as np
+import pytest
 from functions_testing import (
     verify_circuit_clean_auxiliary,
     verify_circuit_clean_relative_auxiliary,
@@ -55,6 +56,14 @@ class TestMCTNQubitDecomposition:
         self._auxiliary_dict[controls_no] = mct.num_auxiliary_qubits()
 
         return self._auxiliary_dict[controls_no]
+
+    def test_init(self):
+        with pytest.raises(Exception) as e_info:
+            MCTNQubitDecomposition(2)
+
+        assert e_info.value.args[0] == "Number of controls must be >= 5 for this implementation"
+
+        assert MCTNQubitDecomposition(5)
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_n_qubit_decomposition.py
+++ b/test/implementations/test_mct_n_qubit_decomposition.py
@@ -58,10 +58,10 @@ class TestMCTNQubitDecomposition:
         return self._auxiliary_dict[controls_no]
 
     def test_init(self):
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(
+            ValueError, match="Number of controls must be >= 5 for this implementation"
+        ):
             MCTNQubitDecomposition(2)
-
-        assert e_info.value.args[0] == "Number of controls must be >= 5 for this implementation"
 
         assert MCTNQubitDecomposition(5)
 

--- a/test/implementations/test_mct_no_auxiliary.py
+++ b/test/implementations/test_mct_no_auxiliary.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import numpy as np
+import pytest
 from functions_testing import verify_circuit_no_auxiliary, verify_circuit_no_auxiliary_relative
 from qiskit.quantum_info.operators import Operator
 
@@ -32,6 +33,14 @@ class TestMCTNoAuxiliary:
             return self._reverse_matrix_dict[controls_no]
         else:
             return self._matrix_dict[controls_no]
+
+    def test_init(self):
+        with pytest.raises(Exception) as e_info:
+            MCTNoAuxiliary(1)
+
+        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
+
+        assert MCTNoAuxiliary(3)
 
     def test_circuit_no_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_no_auxiliary.py
+++ b/test/implementations/test_mct_no_auxiliary.py
@@ -35,10 +35,10 @@ class TestMCTNoAuxiliary:
             return self._matrix_dict[controls_no]
 
     def test_init(self):
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(
+            ValueError, match="Number of controls must be >= 2 for this implementation"
+        ):
             MCTNoAuxiliary(1)
-
-        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
 
         assert MCTNoAuxiliary(3)
 

--- a/test/implementations/test_mct_no_auxiliary.py
+++ b/test/implementations/test_mct_no_auxiliary.py
@@ -40,7 +40,10 @@ class TestMCTNoAuxiliary:
         ):
             MCTNoAuxiliary(1)
 
-        assert MCTNoAuxiliary(3)
+        try:
+            MCTNoAuxiliary(3)
+        except Exception:
+            assert False, "object MCTBarenco74Dirty(3) was not created, but it should be"
 
     def test_circuit_no_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_no_auxiliary_relative.py
+++ b/test/implementations/test_mct_no_auxiliary_relative.py
@@ -40,7 +40,10 @@ class TestMCTNoAuxiliaryRelative:
         ):
             MCTNoAuxiliaryRelative(1)
 
-        assert MCTNoAuxiliaryRelative(2)
+        try:
+            MCTNoAuxiliaryRelative(2)
+        except Exception:
+            assert False, "object MCTNoAuxiliaryRelative(2) was not created, but it should be"
 
     def test_circuit_no_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_no_auxiliary_relative.py
+++ b/test/implementations/test_mct_no_auxiliary_relative.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import numpy as np
+import pytest
 from functions_testing import verify_circuit_no_auxiliary, verify_circuit_no_auxiliary_relative
 from qiskit.quantum_info.operators import Operator
 
@@ -32,6 +33,14 @@ class TestMCTNoAuxiliaryRelative:
             return self._reverse_matrix_dict[controls_no]
         else:
             return self._matrix_dict[controls_no]
+
+    def test_init(self):
+        with pytest.raises(Exception) as e_info:
+            MCTNoAuxiliaryRelative(1)
+
+        assert e_info.value.args[0] == "Number of controls must be 2 or 3 for this implementation"
+
+        assert MCTNoAuxiliaryRelative(2)
 
     def test_circuit_no_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_no_auxiliary_relative.py
+++ b/test/implementations/test_mct_no_auxiliary_relative.py
@@ -35,10 +35,10 @@ class TestMCTNoAuxiliaryRelative:
             return self._matrix_dict[controls_no]
 
     def test_init(self):
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(
+            ValueError, match="Number of controls must be 2 or 3 for this implementation"
+        ):
             MCTNoAuxiliaryRelative(1)
-
-        assert e_info.value.args[0] == "Number of controls must be 2 or 3 for this implementation"
 
         assert MCTNoAuxiliaryRelative(2)
 

--- a/test/implementations/test_mct_parallel_decomposition.py
+++ b/test/implementations/test_mct_parallel_decomposition.py
@@ -58,10 +58,10 @@ class TestMCTParallelDecomposition:
         return self._auxiliary_dict[controls_no]
 
     def test_init(self):
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(
+            ValueError, match="Number of controls must be >= 3 for this implementation"
+        ):
             MCTParallelDecomposition(2)
-
-        assert e_info.value.args[0] == "Number of controls must be >= 3 for this implementation"
 
         assert MCTParallelDecomposition(4)
 

--- a/test/implementations/test_mct_parallel_decomposition.py
+++ b/test/implementations/test_mct_parallel_decomposition.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import numpy as np
+import pytest
 from functions_testing import (
     verify_circuit_clean_auxiliary,
     verify_circuit_clean_relative_auxiliary,
@@ -55,6 +56,14 @@ class TestMCTParallelDecomposition:
         self._auxiliary_dict[controls_no] = mct.num_auxiliary_qubits()
 
         return self._auxiliary_dict[controls_no]
+
+    def test_init(self):
+        with pytest.raises(Exception) as e_info:
+            MCTParallelDecomposition(2)
+
+        assert e_info.value.args[0] == "Number of controls must be >= 3 for this implementation"
+
+        assert MCTParallelDecomposition(4)
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_parallel_decomposition.py
+++ b/test/implementations/test_mct_parallel_decomposition.py
@@ -63,7 +63,10 @@ class TestMCTParallelDecomposition:
         ):
             MCTParallelDecomposition(2)
 
-        assert MCTParallelDecomposition(4)
+        try:
+            MCTParallelDecomposition(4)
+        except Exception:
+            assert False, "object MCTParallelDecomposition(4) was not created, but it should be"
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_recursion.py
+++ b/test/implementations/test_mct_recursion.py
@@ -63,7 +63,10 @@ class TestMCTRecursion:
         ):
             MCTRecursion(1)
 
-        assert MCTRecursion(3)
+        try:
+            MCTRecursion(5)
+        except Exception:
+            assert False, "object MCTRecursion(5) was not created, but it should be"
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_recursion.py
+++ b/test/implementations/test_mct_recursion.py
@@ -58,10 +58,10 @@ class TestMCTRecursion:
         return self._auxiliary_dict[controls_no]
 
     def test_init(self):
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(
+            ValueError, match="Number of controls must be >= 2 for this implementation"
+        ):
             MCTRecursion(1)
-
-        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
 
         assert MCTRecursion(3)
 

--- a/test/implementations/test_mct_recursion.py
+++ b/test/implementations/test_mct_recursion.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import numpy as np
+import pytest
 from functions_testing import (
     verify_circuit_clean_auxiliary,
     verify_circuit_clean_relative_auxiliary,
@@ -55,6 +56,14 @@ class TestMCTRecursion:
         self._auxiliary_dict[controls_no] = mct.num_auxiliary_qubits()
 
         return self._auxiliary_dict[controls_no]
+
+    def test_init(self):
+        with pytest.raises(Exception) as e_info:
+            MCTRecursion(1)
+
+        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
+
+        assert MCTRecursion(3)
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_vchain.py
+++ b/test/implementations/test_mct_vchain.py
@@ -63,7 +63,10 @@ class TestMCTVChain:
         ):
             MCTVChain(1)
 
-        assert MCTVChain(3)
+        try:
+            MCTVChain(5)
+        except Exception:
+            assert False, "object MCTVChain(5) was not created, but it should be"
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_vchain.py
+++ b/test/implementations/test_mct_vchain.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import numpy as np
+import pytest
 from functions_testing import (
     verify_circuit_clean_auxiliary,
     verify_circuit_clean_relative_auxiliary,
@@ -55,6 +56,14 @@ class TestMCTVChain:
         self._auxiliary_dict[controls_no] = mct.num_auxiliary_qubits()
 
         return self._auxiliary_dict[controls_no]
+
+    def test_init(self):
+        with pytest.raises(Exception) as e_info:
+            MCTVChain(1)
+
+        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
+
+        assert MCTVChain(3)
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_vchain.py
+++ b/test/implementations/test_mct_vchain.py
@@ -58,10 +58,10 @@ class TestMCTVChain:
         return self._auxiliary_dict[controls_no]
 
     def test_init(self):
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(
+            ValueError, match="Number of controls must be >= 2 for this implementation"
+        ):
             MCTVChain(1)
-
-        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
 
         assert MCTVChain(3)
 

--- a/test/implementations/test_mct_vchain_dirty.py
+++ b/test/implementations/test_mct_vchain_dirty.py
@@ -63,7 +63,10 @@ class TestMCTVChainDirty:
         ):
             MCTVChainDirty(1)
 
-        assert MCTVChainDirty(3)
+        try:
+            MCTVChainDirty(5)
+        except Exception:
+            assert False, "object MCTVChainDirty(5) was not created, but it should be"
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_vchain_dirty.py
+++ b/test/implementations/test_mct_vchain_dirty.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import numpy as np
+import pytest
 from functions_testing import (
     verify_circuit_clean_auxiliary,
     verify_circuit_clean_relative_auxiliary,
@@ -55,6 +56,14 @@ class TestMCTVChainDirty:
         self._auxiliary_dict[controls_no] = mct.num_auxiliary_qubits()
 
         return self._auxiliary_dict[controls_no]
+
+    def test_init(self):
+        with pytest.raises(Exception) as e_info:
+            MCTVChainDirty(1)
+
+        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
+
+        assert MCTVChainDirty(3)
 
     def test_circuit_clean_auxiliary(self):
         for controls_no in self._controls_no_list:

--- a/test/implementations/test_mct_vchain_dirty.py
+++ b/test/implementations/test_mct_vchain_dirty.py
@@ -58,10 +58,10 @@ class TestMCTVChainDirty:
         return self._auxiliary_dict[controls_no]
 
     def test_init(self):
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(
+            ValueError, match="Number of controls must be >= 2 for this implementation"
+        ):
             MCTVChainDirty(1)
-
-        assert e_info.value.args[0] == "Number of controls must be >= 2 for this implementation"
 
         assert MCTVChainDirty(3)
 


### PR DESCRIPTION
all implementations were asserting control numbers >=2 which is too few for some.
This PR fixes this number according to the implementation and raises an appropriate error.

Also, `pass` has been removed from `__init__`